### PR TITLE
fix: error 미들웨어사용

### DIFF
--- a/BE/src/controllers/auth.controller.js
+++ b/BE/src/controllers/auth.controller.js
@@ -1,6 +1,6 @@
 import { addUserService, loginUserService } from "../services/auth.service.js";
 
-export const addUserController = async (req, res) => {
+export const addUserController = async (req, res, next) => {
   try {
     const user = await addUserService(req.body);
 
@@ -8,13 +8,11 @@ export const addUserController = async (req, res) => {
       data: user.data,
     });
   } catch (error) {
-    res.status(error.status || 500).json({
-      error: error.message,
-    });
+    next(error);
   }
 };
 
-export const loginUserControl = async (req, res) => {
+export const loginUserControl = async (req, res, next) => {
   try {
     const user = await loginUserService(req.body);
 
@@ -22,8 +20,6 @@ export const loginUserControl = async (req, res) => {
       data: user.data,
     });
   } catch (error) {
-    res.status(error.status || 500).json({
-      error: error.message,
-    });
+    next(error);
   }
 };

--- a/BE/src/controllers/company.controller.js
+++ b/BE/src/controllers/company.controller.js
@@ -5,26 +5,26 @@ import {
   getCompanyInvestmentsService,
 } from "../services/company.service.js";
 
-export const getCompaniesController = async (req, res) => {
+export const getCompaniesController = async (req, res, next) => {
   try {
     const companies = await getCompaniesService(req.query);
     res.status(200).json({ data: companies.data, meta: companies.meta });
   } catch (error) {
-    res.status(500).json({ error: error.message });
+    next(error);
   }
 };
 
-export const getCompanyByIdController = async (req, res) => {
+export const getCompanyByIdController = async (req, res, next) => {
   try {
     const companyId = Number(req.params.companyId);
     const company = await getCompanyByIdService(companyId);
     res.status(200).json({ data: company.data });
   } catch (error) {
-    res.status(500).json({ error: error.message });
+    next(error);
   }
 };
 
-export const getCompanyInvestmentsController = async (req, res) => {
+export const getCompanyInvestmentsController = async (req, res, next) => {
   try {
     const companyId = Number(req.params.companyId);
     const companyInvestments = await getCompanyInvestmentsService(
@@ -35,7 +35,7 @@ export const getCompanyInvestmentsController = async (req, res) => {
       .status(200)
       .json({ data: companyInvestments.data, meta: companyInvestments.meta });
   } catch (error) {
-    res.status(500).json({ error: error.message });
+    next(error);
   }
 };
 
@@ -44,7 +44,9 @@ export const addCompanyInvestmentController = async (req, res, next) => {
     const companyId = Number(req.params.companyId);
 
     if (Number.isNaN(companyId)) {
-      return res.status(400).json({ error: "유효한 ID가 아닙니다." });
+      const error = new Error("유효한 ID가 아닙니다.");
+      error.status = 400;
+      throw error;
     }
 
     const investment = await addCompanyInvestmentService(companyId, req.body);

--- a/BE/src/controllers/compare.controller.js
+++ b/BE/src/controllers/compare.controller.js
@@ -4,41 +4,55 @@ import {
   getComparesService,
 } from "../services/compare.service.js";
 
-export const addComparesController = async (req, res) => {
+export const addComparesController = async (req, res, next) => {
   try {
     const companyId = Number(req.body.companyId);
     const userId = Number(req.params.userId);
+
     if (Number.isNaN(userId) || Number.isNaN(companyId)) {
-      return res.status(400).json({ error: "유효한 ID가 아닙니다." });
+      const error = new Error("유효한 ID가 아닙니다.");
+      error.status = 400;
+      throw error;
     }
+
     const compares = await addComparesService(userId, companyId);
     res.status(201).json({ message: compares.message });
   } catch (error) {
-    res.status(error.status || 500).json({ error: error.message });
+    next(error);
   }
 };
-export const getComparesController = async (req, res) => {
+
+export const getComparesController = async (req, res, next) => {
   try {
     const userId = Number(req.params.userId);
+
     if (Number.isNaN(userId)) {
-      return res.status(400).json({ error: "유효한 ID가 아닙니다." });
+      const error = new Error("유효한 ID가 아닙니다.");
+      error.status = 400;
+      throw error;
     }
+
     const compares = await getComparesService(userId);
     res.status(200).json({ data: compares.data });
   } catch (error) {
-    res.status(error.status || 500).json({ error: error.message });
+    next(error);
   }
 };
-export const deleteCompareController = async (req, res) => {
+
+export const deleteCompareController = async (req, res, next) => {
   try {
     const userId = Number(req.params.userId);
     const companyId = Number(req.params.companyId);
+
     if (Number.isNaN(userId) || Number.isNaN(companyId)) {
-      return res.status(400).json({ error: "유효한 ID가 아닙니다." });
+      const error = new Error("유효한 ID가 아닙니다.");
+      error.status = 400;
+      throw error;
     }
+
     await deleteCompareService(userId, companyId);
     res.status(200).json({ message: "비교기업이 선택 해제 되었습니다." });
   } catch (error) {
-    res.status(error.status || 500).json({ error: error.message });
+    next(error);
   }
 };

--- a/BE/src/controllers/favorite.controller.js
+++ b/BE/src/controllers/favorite.controller.js
@@ -5,53 +5,72 @@ import {
   getLastFavoriteService,
 } from "../services/favorite.service.js";
 
-export const addFavoriteController = async (req, res) => {
+export const addFavoriteController = async (req, res, next) => {
   try {
     const companyId = Number(req.body.companyId);
     const userId = Number(req.params.userId);
+
     if (Number.isNaN(userId) || Number.isNaN(companyId)) {
-      return res.status(400).json({ error: "유효한 ID가 아닙니다." });
+      const error = new Error("유효한 ID가 아닙니다.");
+      error.status = 400;
+      throw error;
     }
+
     const favorites = await addFavoriteService(userId, companyId);
     res.status(201).json({ message: favorites.message });
   } catch (error) {
-    res.status(error.status || 500).json({ error: error.message });
+    next(error);
   }
 };
-export const getFavoritesController = async (req, res) => {
+
+export const getFavoritesController = async (req, res, next) => {
   try {
     const userId = Number(req.params.userId);
+
     if (Number.isNaN(userId)) {
-      return res.status(400).json({ error: "유효한 ID가 아닙니다." });
+      const error = new Error("유효한 ID가 아닙니다.");
+      error.status = 400;
+      throw error;
     }
+
     const favorites = await getFavoritesService(userId);
     res.status(200).json({ data: favorites.data });
   } catch (error) {
-    res.status(error.status || 500).json({ error: error.message });
+    next(error);
   }
 };
-export const deleteFavoriteController = async (req, res) => {
+
+export const deleteFavoriteController = async (req, res, next) => {
   try {
     const userId = Number(req.params.userId);
     const companyId = Number(req.params.companyId);
+
     if (Number.isNaN(userId) || Number.isNaN(companyId)) {
-      return res.status(400).json({ error: "유효한 ID가 아닙니다." });
+      const error = new Error("유효한 ID가 아닙니다.");
+      error.status = 400;
+      throw error;
     }
+
     await deleteFavoriteService(userId, companyId);
     res.status(200).json({ message: "기업이 선택 해제 되었습니다." });
   } catch (error) {
-    res.status(error.status || 500).json({ error: error.message });
+    next(error);
   }
 };
-export const getLastFavoriteController = async (req, res) => {
+
+export const getLastFavoriteController = async (req, res, next) => {
   try {
     const userId = Number(req.params.userId);
+
     if (Number.isNaN(userId)) {
-      return res.status(400).json({ error: "유효한 ID가 아닙니다." });
+      const error = new Error("유효한 ID가 아닙니다.");
+      error.status = 400;
+      throw error;
     }
+
     const result = await getLastFavoriteService(userId);
     res.status(200).json({ data: result.data, total: result.total });
   } catch (error) {
-    res.status(error.status || 500).json({ error: error.message });
+    next(error);
   }
 };

--- a/BE/src/controllers/investment.controller.js
+++ b/BE/src/controllers/investment.controller.js
@@ -7,9 +7,13 @@ import {
 export const addFavoriteInvestmentController = async (req, res, next) => {
   try {
     const userId = Number(req.params.userId);
+
     if (Number.isNaN(userId)) {
-      return res.status(400).json({ error: "유효한 ID가 아닙니다." });
+      const error = new Error("유효한 ID가 아닙니다.");
+      error.status = 400;
+      throw error;
     }
+
     const investment = await addFavoriteInvestmentService(userId, req.body);
     res.status(201).json({ message: investment.message });
   } catch (error) {
@@ -20,13 +24,21 @@ export const addFavoriteInvestmentController = async (req, res, next) => {
 export const updateInvestmentController = async (req, res, next) => {
   try {
     const userId = Number(req.params.userId);
+
     if (Number.isNaN(userId)) {
-      return res.status(400).json({ error: "유효한 ID가 아닙니다." });
+      const error = new Error("유효한 ID가 아닙니다.");
+      error.status = 400;
+      throw error;
     }
+
     const investmentId = Number(req.params.investmentId);
+
     if (Number.isNaN(investmentId)) {
-      return res.status(400).json({ error: "유효한 투자 내역이 아닙니다." });
+      const error = new Error("유효한 투자 내역이 아닙니다.");
+      error.status = 400;
+      throw error;
     }
+
     const updateInvestment = await updateInvestmentService(
       userId,
       investmentId,
@@ -41,13 +53,21 @@ export const updateInvestmentController = async (req, res, next) => {
 export const deleteInvestmentController = async (req, res, next) => {
   try {
     const userId = Number(req.params.userId);
+
     if (Number.isNaN(userId)) {
-      return res.status(400).json({ error: "유효한 ID가 아닙니다." });
+      const error = new Error("유효한 ID가 아닙니다.");
+      error.status = 400;
+      throw error;
     }
+
     const investmentId = Number(req.params.investmentId);
+
     if (Number.isNaN(investmentId)) {
-      return res.status(400).json({ error: "유효한 투자 내역이 아닙니다." });
+      const error = new Error("유효한 투자 내역이 아닙니다.");
+      error.status = 400;
+      throw error;
     }
+
     const deleteInvestment = await deleteInvestmentService(
       userId,
       investmentId,

--- a/BE/src/controllers/selection.controller.js
+++ b/BE/src/controllers/selection.controller.js
@@ -3,6 +3,7 @@ import {
   getSelectionsService,
   resetSelectionsService,
 } from "../services/selection.service.js";
+import { companySortOrder } from "../utils/sort.js";
 
 export const resetSelectionsController = async (req, res, next) => {
   try {


### PR DESCRIPTION
## 📌 개요

- 기존 컨트롤러 내부에서 직접 처리하던 에러 응답 로직을 제거하고, 공통 `error.middleware`를 사용하도록 구조를 통일했습니다.
- `next(error)` 기반으로 에러를 전달하도록 수정하여 컨트롤러 책임을 단순화하고, 에러 응답 형식을 일관되게 유지할 수 있도록 개선했습니다.

- ***

## ✨ 작업 내용

- 각 컨트롤러의 `catch` 블록에서 직접 `res.status(...).json(...)` 하던 로직을 제거했습니다.
- 컨트롤러에서 발생한 에러를 `next(error)`로 전달하도록 수정했습니다.
- `error.middleware.js`를 통해 공통 에러 응답이 처리되도록 구조를 변경했습니다.
- 일부 컨트롤러에서 직접 반환하던 `400 Bad Request` 응답도 `throw error` 방식으로 통일했습니다.

- ***

## 🔧 변경 사항

- 컨트롤러 함수에 `next` 파라미터를 추가했습니다.
- `try-catch` 내부에서 직접 에러 응답을 반환하던 방식을 제거했습니다.
- 유효하지 않은 ID, 잘못된 요청값 등도 `Error` 객체와 `status`를 설정해 미들웨어로 넘기도록 수정했습니다.
- 에러 응답 처리를 컨트롤러가 아닌 `error.middleware.js`에서 담당하도록 변경했습니다.

- ***

## 🧪 테스트 방법

- Postman으로 각 API 요청 후 정상 응답이 기존과 동일하게 반환되는지 확인했습니다.
- 잘못된 ID, 존재하지 않는 데이터, 중복 데이터 등의 요청을 보내 에러가 `error.middleware.js`를 통해 일관된 형식으로 반환되는지 확인했습니다.

- ***


## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 에러 없음
- [x] 콘솔 경고 없음
- [x] 코드 컨벤션 준수
- [x] PR 제목 컨벤션 준수

---

## 🔗 관련 이슈

- close #44 